### PR TITLE
fix: Making the design more responsive

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,13 +9,13 @@
 	<div id="fh5co-content">
 		<div class="container">
 			<div class="row">
-				<div class="col-md-8 col-md-offset-3">
+				<div class="col-lg-8 offset-lg-3">
 					<div class="row">
-						<div class="col-md-2">
+						<div class="col-lg-2">
 						<?php include(THEME_DIR_PHP.'sidebar.php') ?>
 						</div>
 
-						<div class="col-md-6">
+						<div class="col-lg-6">
 						<?php include(THEME_DIR_PHP.'home.php') ?>
 						</div>
 					</div>
@@ -28,7 +28,7 @@
 	<footer id="fh5co-footer">
 		<div class="container">
 			<div class="row">
-				<div class="col-md-10 col-md-offset-1 text-center">
+				<div class="col-lg-10 offset-lg-1 text-center">
 					<p>
 						<?php echo $site->footer() ?>
 						<br>


### PR DESCRIPTION
offset-md-* was misstyped which caused an annoying effect of the webpage not being centered, also changing md for lg in makes the theme to be seen better on medium size screens like browsers in tiling windows WM getting the half of a common display. This solves #5 

![2020-07-17-192742_572x1023_scrot](https://user-images.githubusercontent.com/25019174/87814487-2322f600-c864-11ea-9337-e355e957fe99.png)
![2020-07-17-192749_764x1023_scrot](https://user-images.githubusercontent.com/25019174/87814494-24ecb980-c864-11ea-89db-40e06d5d3d8e.png)
![2020-07-17-192806_1148x1023_scrot](https://user-images.githubusercontent.com/25019174/87814496-261de680-c864-11ea-8b1c-547b74d09ec4.png)
![2020-07-17-192815_1340x1023_scrot](https://user-images.githubusercontent.com/25019174/87814499-274f1380-c864-11ea-84d6-011f40e5be7a.png)
