### PR TITLE
Adding hyperlinks to blog post titles.

### DIFF
--- a/php/home.php
+++ b/php/home.php
@@ -3,13 +3,15 @@
         <?php foreach ($content as $page): ?>
                 <article class="page">
                         <header>
+                            <?php if ( $page->title() ): ?>
                             <h2>
                                 <a href="<?php echo htmlentities($page->permalink(), ENT_QUOTES | ENT_HTML401)?>">
                                     <?php 
-                                        echo htmlentities($page->title() ? $page->title() : $page->permalink() );
+                                        echo htmlentities( $page->title() );
                                     ?>
                                 </a>
                             </h2>
+                            <?php endif; ?>
                         </header>
                         <?php if ($page->coverImage()): ?>
                         <img src="<?php echo $page->coverImage() ?>" alt="<?php echo $page->slug() ?>">
@@ -18,6 +20,10 @@
                         <?php echo $page->content() ?>
 
                         <footer>
+                                <a href="<?php echo htmlentities($page->permalink(), ENT_QUOTES | ENT_HTML401)?>">
+                                    <?php echo htmlentities( $L->get('Read this article.') ); ?>
+                                </a>
+                                <br/>
                                 <?php echo $page->date() ?>
                         </footer>
                 </article>

--- a/php/home.php
+++ b/php/home.php
@@ -2,12 +2,15 @@
 <section class="content">
         <?php foreach ($content as $page): ?>
                 <article class="page">
-                        <?php if($page->title()): ?>
                         <header>
-                                <h2><?php echo $page->title() ?></h2>
+                            <h2>
+                                <a href="<?php echo htmlentities($page->permalink(), ENT_QUOTES | ENT_HTML401)?>">
+                                    <?php 
+                                        echo htmlentities($page->title() ? $page->title() : $page->permalink() );
+                                    ?>
+                                </a>
+                            </h2>
                         </header>
-                        <?php endif ?>
-
                         <?php if ($page->coverImage()): ?>
                         <img src="<?php echo $page->coverImage() ?>" alt="<?php echo $page->slug() ?>">
                         <?php endif ?>


### PR DESCRIPTION
Adding hyperlinks to blog post titles, if there is no title, page permalink is used as a title.

Issue #2

The usage of htmlentities is related to issue #4, I filtered also `'` in urls because there is a chance other people commiting changes to this repo without knowing htmlentities by default doesn't filter `'` and using `'` as href delimiter. 