### PR TITLE
Avoiding long words going out of their reserved space.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -29,6 +29,8 @@ nav,
 section,
 summary {
   display: block;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 audio,


### PR DESCRIPTION
This is how it looks now.
![2020-07-23-130552_476x1023_scrot](https://user-images.githubusercontent.com/25019174/88279999-4d056e00-cce5-11ea-8f86-5f6cb548e2ee.png)

Issue #6